### PR TITLE
Added the ability to set the honoree's name in the reply email field.

### DIFF
--- a/admin-views/templates.php
+++ b/admin-views/templates.php
@@ -98,7 +98,7 @@ class Dgx_Donate_Admin_Templates_View {
 			'tributetext' => array(
 				'option' => 'dgx_donate_email_trib',
 				'label' => __( 'Tribute Gift', 'dgx-donate' ),
-				'description' => __( 'This message will be included when the donor elects to make their donation a tribute gift.', 'dgx-donate' ),
+				'description' => __( 'This message will be included when the donor elects to make their donation a tribute gift. (placeholder [honoreename] is available)', 'dgx-donate' ),
 				'type' => 'textarea',
 				'cols' => 40,
 				'rows' => 3

--- a/dgx-donate-admin.php
+++ b/dgx-donate-admin.php
@@ -94,7 +94,7 @@ function dgx_donate_init_defaults()
 	$tributeText = get_option('dgx_donate_email_trib');
 	if (empty($tributeText))
 	{
-		$tributeText = "You have asked to make this donation in honor of or memory of someone else.  Thank you!  We will notify the ";
+		$tributeText = "You have asked to make this donation in honor of or memory of [honoreename].  Thank you!  We will notify the ";
 		$tributeText .= "honoree within the next 5-10 business days.";
 		update_option('dgx_donate_email_trib', $tributeText);
 	}

--- a/dgx-donate.php
+++ b/dgx-donate.php
@@ -831,6 +831,8 @@ function dgx_donate_send_thank_you_email($donationID, $testAddress="")
 		$mailingListJoin = "TRUE";
 		// tribute y/n
 		$tribute = "TRUE";
+		// honoreename
+		$honoreeName = "Bogey";
 		// employer match
 		$employer_name = "Global Corporation";
 	}
@@ -858,6 +860,8 @@ function dgx_donate_send_thank_you_email($donationID, $testAddress="")
 		$mailingListJoin = get_post_meta($donationID, '_dgx_donate_add_to_mailing_list', true);
 		// tribute y/n
 		$tribute = get_post_meta($donationID, '_dgx_donate_tribute_gift', true);
+		// honoreename
+		$honoreeName = get_post_meta($donationID, '_dgx_donate_honoree_name', true);
 		// employer match
 		$employer_name = get_post_meta($donationID, '_dgx_doname_employer_name', true);
 	}
@@ -910,6 +914,7 @@ function dgx_donate_send_thank_you_email($donationID, $testAddress="")
 	if ( ! empty( $tribute ) ) {
 		$text = get_option( 'dgx_donate_email_trib' );
 		$text = stripslashes( $text );
+		$text = str_replace( "[honoreename]", $honoreeName, $text );
 		$emailBody .= $text;
 		$emailBody .= "\n\n";
 	}


### PR DESCRIPTION
Allen,

So first off thanks for providing a plugin that's open source and so easy to integrate with WP sites.  My wife works for a non-profit and they are ecstatic about this plugin!  It's been working great, but there are some features she would like to see added, and after getting ridiculous price quotes from web developers, I told her I'd work on it.  I am a professional software developer, but it's all been embedded and real-time code, so I'm starting to dabbling in web development, so feedback and corrections on the pull requests are gladly accepted!

Anywho, the pull request adds the ability to load the honoree's name as a placeholder in the tribute response email.  Makes it a bit more personalized. 

Josh
